### PR TITLE
Fix init.sh looking for wrong env. variable

### DIFF
--- a/8-php5/rhel-7/rootfs/init.sh
+++ b/8-php5/rhel-7/rootfs/init.sh
@@ -22,8 +22,8 @@ else
   if [[ -n "$MYSQL_CLIENT_CREATE_DATABASE_USER" && -z "$MYSQL_CLIENT_CREATE_DATABASE_PASSWORD" ]]; then
     empty_password_error MYSQL_CLIENT_CREATE_DATABASE_PASSWORD
   fi
-  # WordPress database
-  if [[ -z "$WORDPRESS_DATABASE_PASSWORD" ]]; then
-    empty_password_error WORDPRESS_DATABASE_PASSWORD
+  # Drupal database
+  if [[ -z "$DRUPAL_DATABASE_PASSWORD" ]]; then
+    empty_password_error DRUPAL_DATABASE_PASSWORD
   fi
 fi

--- a/8/debian-9/rootfs/init.sh
+++ b/8/debian-9/rootfs/init.sh
@@ -22,8 +22,8 @@ else
   if [[ -n "$MYSQL_CLIENT_CREATE_DATABASE_USER" && -z "$MYSQL_CLIENT_CREATE_DATABASE_PASSWORD" ]]; then
     empty_password_error MYSQL_CLIENT_CREATE_DATABASE_PASSWORD
   fi
-  # WordPress database
-  if [[ -z "$WORDPRESS_DATABASE_PASSWORD" ]]; then
-    empty_password_error WORDPRESS_DATABASE_PASSWORD
+  # Drupal database
+  if [[ -z "$DRUPAL_DATABASE_PASSWORD" ]]; then
+    empty_password_error DRUPAL_DATABASE_PASSWORD
   fi
 fi

--- a/8/ol-7/rootfs/init.sh
+++ b/8/ol-7/rootfs/init.sh
@@ -22,8 +22,8 @@ else
   if [[ -n "$MYSQL_CLIENT_CREATE_DATABASE_USER" && -z "$MYSQL_CLIENT_CREATE_DATABASE_PASSWORD" ]]; then
     empty_password_error MYSQL_CLIENT_CREATE_DATABASE_PASSWORD
   fi
-  # WordPress database
-  if [[ -z "$WORDPRESS_DATABASE_PASSWORD" ]]; then
-    empty_password_error WORDPRESS_DATABASE_PASSWORD
+  # Drupal database
+  if [[ -z "$DRUPAL_DATABASE_PASSWORD" ]]; then
+    empty_password_error DRUPAL_DATABASE_PASSWORD
   fi
 fi

--- a/8/rhel-7/rootfs/init.sh
+++ b/8/rhel-7/rootfs/init.sh
@@ -22,8 +22,8 @@ else
   if [[ -n "$MYSQL_CLIENT_CREATE_DATABASE_USER" && -z "$MYSQL_CLIENT_CREATE_DATABASE_PASSWORD" ]]; then
     empty_password_error MYSQL_CLIENT_CREATE_DATABASE_PASSWORD
   fi
-  # WordPress database
-  if [[ -z "$WORDPRESS_DATABASE_PASSWORD" ]]; then
-    empty_password_error WORDPRESS_DATABASE_PASSWORD
+  # Drupal database
+  if [[ -z "$DRUPAL_DATABASE_PASSWORD" ]]; then
+    empty_password_error DRUPAL_DATABASE_PASSWORD
   fi
 fi


### PR DESCRIPTION
### What this PR does / why we need it:

The init.sh file that checks for wrong password configuration (based on ALLOW_EMPTY_PASSWORD env. var) it's no using the right env. variables.

### Which issue this PR fixes

fixes https://github.com/bitnami/bitnami-docker-drupal/issues/96
