### PR TITLE
Properly bootstrap Drupal when using an existing database

### DIFF
--- a/8/debian-10/rootfs/opt/bitnami/scripts/drupal-env.sh
+++ b/8/debian-10/rootfs/opt/bitnami/scripts/drupal-env.sh
@@ -77,6 +77,8 @@ export DRUPAL_PROFILE="${DRUPAL_PROFILE:-standard}" # only used during the first
 export DRUPAL_SITE_NAME="${DRUPAL_SITE_NAME:-My blog}" # only used during the first initialization
 export DRUPAL_SKIP_BOOTSTRAP="${DRUPAL_SKIP_BOOTSTRAP:-}" # only used during the first initialization
 export DRUPAL_ENABLE_MODULES="${DRUPAL_ENABLE_MODULES:-}" # only used during the first initialization
+export DRUPAL_CONFIG_DIR="${DRUPAL_CONFIG_DIR:-sites/default/files/config}"
+export DRUPAL_HASH_SALT="${DRUPAL_HASH_SALT:-}"
 
 # Drupal credentials
 export DRUPAL_USERNAME="${DRUPAL_USERNAME:-user}" # only used during the first initialization

--- a/8/debian-10/rootfs/opt/bitnami/scripts/drupal-env.sh
+++ b/8/debian-10/rootfs/opt/bitnami/scripts/drupal-env.sh
@@ -77,7 +77,7 @@ export DRUPAL_PROFILE="${DRUPAL_PROFILE:-standard}" # only used during the first
 export DRUPAL_SITE_NAME="${DRUPAL_SITE_NAME:-My blog}" # only used during the first initialization
 export DRUPAL_SKIP_BOOTSTRAP="${DRUPAL_SKIP_BOOTSTRAP:-}" # only used during the first initialization
 export DRUPAL_ENABLE_MODULES="${DRUPAL_ENABLE_MODULES:-}" # only used during the first initialization
-export DRUPAL_CONFIG_SYNC_DIR="${DRUPAL_CONFIG_SYNC_DIR:-sites/default/files/config}"
+export DRUPAL_CONFIG_SYNC_DIR="${DRUPAL_CONFIG_SYNC_DIR:-}"
 export DRUPAL_HASH_SALT="${DRUPAL_HASH_SALT:-}"
 
 # Drupal credentials

--- a/8/debian-10/rootfs/opt/bitnami/scripts/drupal-env.sh
+++ b/8/debian-10/rootfs/opt/bitnami/scripts/drupal-env.sh
@@ -77,7 +77,7 @@ export DRUPAL_PROFILE="${DRUPAL_PROFILE:-standard}" # only used during the first
 export DRUPAL_SITE_NAME="${DRUPAL_SITE_NAME:-My blog}" # only used during the first initialization
 export DRUPAL_SKIP_BOOTSTRAP="${DRUPAL_SKIP_BOOTSTRAP:-}" # only used during the first initialization
 export DRUPAL_ENABLE_MODULES="${DRUPAL_ENABLE_MODULES:-}" # only used during the first initialization
-export DRUPAL_CONFIG_DIR="${DRUPAL_CONFIG_DIR:-sites/default/files/config}"
+export DRUPAL_CONFIG_SYNC_DIR="${DRUPAL_CONFIG_SYNC_DIR:-sites/default/files/config}"
 export DRUPAL_HASH_SALT="${DRUPAL_HASH_SALT:-}"
 
 # Drupal credentials

--- a/8/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
+++ b/8/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
@@ -151,7 +151,7 @@ drupal_initialize() {
                 drupal_set_database_ssl_settings
             fi
             drupal_create_config_directory "$DRUPAL_BASE_DIR/$DRUPAL_CONFIG_SYNC_DIR"
-            drupal_conf_set "\$settings['config_sync_directory']" "$DRUPAL_CONFIG_SYNC_DIR" no
+            drupal_conf_set "\$settings['config_sync_directory']" "$DRUPAL_CONFIG_SYNC_DIR"
             drupal_set_hash_salt
             drupal_update_database
         fi

--- a/8/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
+++ b/8/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
@@ -145,19 +145,19 @@ drupal_initialize() {
             fi
         else
             info "An already initialized Drupal database was provided, configuration will be skipped"
-			if is_empty_value "$DRUPAL_DATABASE_TLS_CA_FILE"; then
-				drupal_set_database_settings
-			else
-				drupal_set_database_ssl_settings
-			fi
-			drupal_create_config_directory "$DRUPAL_BASE_DIR/$DRUPAL_CONFIG_SYNC_DIR"
-			drupal_conf_set "\$settings['config_sync_directory']" "$DRUPAL_CONFIG_SYNC_DIR" no
-			drupal_set_hash_salt
+            if is_empty_value "$DRUPAL_DATABASE_TLS_CA_FILE"; then
+                drupal_set_database_settings
+            else
+                drupal_set_database_ssl_settings
+            fi
+            drupal_create_config_directory "$DRUPAL_BASE_DIR/$DRUPAL_CONFIG_SYNC_DIR"
+            drupal_conf_set "\$settings['config_sync_directory']" "$DRUPAL_CONFIG_SYNC_DIR" no
+            drupal_set_hash_salt
             drupal_update_database
         fi
 
-		info "Flushing Drupal cache"
-		drupal_flush_cache
+        info "Flushing Drupal cache"
+        drupal_flush_cache
 
         info "Persisting Drupal installation"
         persist_app "$app_name" "$DRUPAL_DATA_TO_PERSIST"
@@ -299,24 +299,24 @@ drupal_site_install() {
 #   None
 #########################
 drupal_create_config_directory() {
-	if [[ -z $DRUPAL_CONFIG_SYNC_DIR ]]; then
-		# In order to use Drush commands we need to have a value for
-		# config_sync_directory or it will throw an error so we add a
-		# temp value here first
-		drupal_conf_set "\$settings['config_sync_directory']" "temp" no
-		DRUPAL_CONFIG_SYNC_DIR="sites/default/files/config_$(drush eval "echo(Drupal\Component\Utility\Crypt::randomBytesBase64(55))")"
-		debug_execute mkdir "$DRUPAL_BASE_DIR/$DRUPAL_CONFIG_SYNC_DIR"
-	else
-		debug_execute mkdir "$@"
-	fi
+    if [[ -z $DRUPAL_CONFIG_SYNC_DIR ]]; then
+        # In order to use Drush commands we need to have a value for
+        # config_sync_directory or it will throw an error so we add a
+        # temp value here first
+        drupal_conf_set "\$settings['config_sync_directory']" "temp" no
+        DRUPAL_CONFIG_SYNC_DIR="sites/default/files/config_$(drush eval "echo(Drupal\Component\Utility\Crypt::randomBytesBase64(55))")"
+        debug_execute mkdir "$DRUPAL_BASE_DIR/$DRUPAL_CONFIG_SYNC_DIR"
+    else
+        debug_execute mkdir "$@"
+    fi
 }
 
 drupal_set_hash_salt() {
-	if [[ -z $DRUPAL_HASH_SALT ]]; then
-		drupal_conf_set "\$settings['hash_salt']" "$(drush eval "echo(Drupal\Component\Utility\Crypt::randomBytesBase64(55))")" no
-	else
-		drupal_conf_set "\$settings['hash_salt']" "$DRUPAL_HASH_SALT" no
-	fi
+    if [[ -z $DRUPAL_HASH_SALT ]]; then
+        drupal_conf_set "\$settings['hash_salt']" "$(drush eval "echo(Drupal\Component\Utility\Crypt::randomBytesBase64(55))")" no
+    else
+        drupal_conf_set "\$settings['hash_salt']" "$DRUPAL_HASH_SALT" no
+    fi
 }
 
 ########################

--- a/8/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
+++ b/8/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
@@ -150,8 +150,13 @@ drupal_initialize() {
             else
                 drupal_set_database_ssl_settings
             fi
+
+            # Drupal expects a directory for storing site configuration
+            # For more info see https://www.drupal.org/docs/configuration-management
             drupal_create_config_directory "$DRUPAL_BASE_DIR/$DRUPAL_CONFIG_SYNC_DIR"
             drupal_conf_set "\$settings['config_sync_directory']" "$DRUPAL_CONFIG_SYNC_DIR"
+
+            # Drupal needs a hash value to build one-time login links, cancel links, form tokens, etc.
             drupal_set_hash_salt
             drupal_update_database
         fi

--- a/8/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
+++ b/8/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
@@ -153,8 +153,7 @@ drupal_initialize() {
 
             # Drupal expects a directory for storing site configuration
             # For more info see https://www.drupal.org/docs/configuration-management
-            drupal_create_config_directory "$DRUPAL_BASE_DIR/$DRUPAL_CONFIG_SYNC_DIR"
-            drupal_conf_set "\$settings['config_sync_directory']" "$DRUPAL_CONFIG_SYNC_DIR"
+            drupal_create_config_directory
 
             # Drupal needs a hash value to build one-time login links, cancel links, form tokens, etc.
             drupal_set_hash_salt
@@ -309,6 +308,7 @@ drupal_create_config_directory() {
         config_sync_dir="${DRUPAL_BASE_DIR}/sites/default/files/config_$(generate_random_string -t alphanumeric -c 16)"
     fi
     ensure_dir_exists "$config_sync_dir"
+    drupal_conf_set "\$settings['config_sync_directory']" "$config_sync_dir"
 }
 
 ########################

--- a/8/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
+++ b/8/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
@@ -289,6 +289,15 @@ drupal_site_install() {
     fi
 }
 
+########################
+# Drupal Create Config Directory
+# Globals:
+#   *
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
 drupal_create_config_directory() {
 	if [[ -z $DRUPAL_CONFIG_SYNC_DIR ]]; then
 		# In order to use Drush commands we need to have a value for

--- a/8/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
+++ b/8/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
@@ -151,7 +151,6 @@ drupal_initialize() {
 			drupal_create_config_directory "$DRUPAL_BASE_DIR/$DRUPAL_CONFIG_DIR"
 			drupal_conf_set "\$settings['config_sync_directory']" "$DRUPAL_CONFIG_DIR" no
 			drupal_set_hash_salt
-			cat /opt/bitnami/drupal/sites/default/settings.php
             drupal_update_database
         fi
 

--- a/8/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
+++ b/8/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
@@ -304,16 +304,11 @@ drupal_site_install() {
 #   None
 #########################
 drupal_create_config_directory() {
-    if [[ -z $DRUPAL_CONFIG_SYNC_DIR ]]; then
-        # In order to use Drush commands we need to have a value for
-        # config_sync_directory or it will throw an error so we add a
-        # temp value here first
-        drupal_conf_set "\$settings['config_sync_directory']" "temp" no
-        DRUPAL_CONFIG_SYNC_DIR="sites/default/files/config_$(drush eval "echo(Drupal\Component\Utility\Crypt::randomBytesBase64(55))")"
-        debug_execute mkdir "$DRUPAL_BASE_DIR/$DRUPAL_CONFIG_SYNC_DIR"
-    else
-        debug_execute mkdir "$@"
+    local config_sync_dir="${DRUPAL_CONFIG_SYNC_DIR:-}"
+    if is_empty_value "$config_sync_dir"; then
+        config_sync_dir="${DRUPAL_BASE_DIR}/sites/default/files/config_$(generate_random_string -t alphanumeric -c 16)"
     fi
+    ensure_dir_exists "$config_sync_dir"
 }
 
 drupal_set_hash_salt() {

--- a/8/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
+++ b/8/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
@@ -148,8 +148,8 @@ drupal_initialize() {
         else
             info "An already initialized Drupal database was provided, configuration will be skipped"
 			drupal_set_database_settings
-			drupal_create_config_directory "$DRUPAL_BASE_DIR/$DRUPAL_CONFIG_DIR"
-			drupal_conf_set "\$settings['config_sync_directory']" "$DRUPAL_CONFIG_DIR" no
+			drupal_create_config_directory "$DRUPAL_BASE_DIR/$DRUPAL_CONFIG_SYNC_DIR"
+			drupal_conf_set "\$settings['config_sync_directory']" "$DRUPAL_CONFIG_SYNC_DIR" no
 			drupal_set_hash_salt
             drupal_update_database
         fi

--- a/8/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
+++ b/8/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
@@ -148,9 +148,7 @@ drupal_initialize() {
         else
             info "An already initialized Drupal database was provided, configuration will be skipped"
 			drupal_set_database_settings
-			echo "Before func $DRUPAL_CONFIG_SYNC_DIR"
 			drupal_create_config_directory "$DRUPAL_BASE_DIR/$DRUPAL_CONFIG_SYNC_DIR"
-			echo "After func $DRUPAL_CONFIG_SYNC_DIR"
 			drupal_conf_set "\$settings['config_sync_directory']" "$DRUPAL_CONFIG_SYNC_DIR" no
 			drupal_set_hash_salt
             drupal_update_database

--- a/8/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
+++ b/8/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
@@ -147,7 +147,11 @@ drupal_initialize() {
             drupal_flush_cache
         else
             info "An already initialized Drupal database was provided, configuration will be skipped"
-			drupal_set_database_settings
+			if is_empty_value "$DRUPAL_DATABASE_TLS_CA_FILE"; then
+				drupal_set_database_settings
+			else
+				drupal_set_database_ssl_settings
+			fi
 			drupal_create_config_directory "$DRUPAL_BASE_DIR/$DRUPAL_CONFIG_SYNC_DIR"
 			drupal_conf_set "\$settings['config_sync_directory']" "$DRUPAL_CONFIG_SYNC_DIR" no
 			drupal_set_hash_salt

--- a/8/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
+++ b/8/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
@@ -143,8 +143,6 @@ drupal_initialize() {
                 info "Configuring SMTP"
                 drupal_configure_smtp
             fi
-            info "Flushing Drupal cache"
-            drupal_flush_cache
         else
             info "An already initialized Drupal database was provided, configuration will be skipped"
 			if is_empty_value "$DRUPAL_DATABASE_TLS_CA_FILE"; then
@@ -157,6 +155,9 @@ drupal_initialize() {
 			drupal_set_hash_salt
             drupal_update_database
         fi
+
+		info "Flushing Drupal cache"
+		drupal_flush_cache
 
         info "Persisting Drupal installation"
         persist_app "$app_name" "$DRUPAL_DATA_TO_PERSIST"

--- a/8/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
+++ b/8/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
@@ -311,12 +311,21 @@ drupal_create_config_directory() {
     ensure_dir_exists "$config_sync_dir"
 }
 
+########################
+# Drupal Create Hash Salt
+# Globals:
+#   *
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
 drupal_set_hash_salt() {
-    if [[ -z $DRUPAL_HASH_SALT ]]; then
-        drupal_conf_set "\$settings['hash_salt']" "$(drush eval "echo(Drupal\Component\Utility\Crypt::randomBytesBase64(55))")" no
-    else
-        drupal_conf_set "\$settings['hash_salt']" "$DRUPAL_HASH_SALT" no
+    local hash_salt="${DRUPAL_HASH_SALT:-}"
+    if is_empty_value "$hash_salt"; then
+        hash_salt="$(generate_random_string -t alphanumeric -c 32)"
     fi
+    drupal_conf_set "\$settings['hash_salt']" "$hash_salt"
 }
 
 ########################

--- a/9/debian-10/rootfs/opt/bitnami/scripts/drupal-env.sh
+++ b/9/debian-10/rootfs/opt/bitnami/scripts/drupal-env.sh
@@ -77,6 +77,7 @@ export DRUPAL_PROFILE="${DRUPAL_PROFILE:-standard}" # only used during the first
 export DRUPAL_SITE_NAME="${DRUPAL_SITE_NAME:-My blog}" # only used during the first initialization
 export DRUPAL_SKIP_BOOTSTRAP="${DRUPAL_SKIP_BOOTSTRAP:-}" # only used during the first initialization
 export DRUPAL_ENABLE_MODULES="${DRUPAL_ENABLE_MODULES:-}" # only used during the first initialization
+export DRUPAL_CONFIG_DIR="${DRUPAL_CONFIG_DIR:-sites/default/files/config}"
 
 # Drupal credentials
 export DRUPAL_USERNAME="${DRUPAL_USERNAME:-user}" # only used during the first initialization

--- a/9/debian-10/rootfs/opt/bitnami/scripts/drupal-env.sh
+++ b/9/debian-10/rootfs/opt/bitnami/scripts/drupal-env.sh
@@ -77,7 +77,7 @@ export DRUPAL_PROFILE="${DRUPAL_PROFILE:-standard}" # only used during the first
 export DRUPAL_SITE_NAME="${DRUPAL_SITE_NAME:-My blog}" # only used during the first initialization
 export DRUPAL_SKIP_BOOTSTRAP="${DRUPAL_SKIP_BOOTSTRAP:-}" # only used during the first initialization
 export DRUPAL_ENABLE_MODULES="${DRUPAL_ENABLE_MODULES:-}" # only used during the first initialization
-export DRUPAL_CONFIG_SYNC_DIR="${DRUPAL_CONFIG_SYNC_DIR:-sites/default/files/config}"
+export DRUPAL_CONFIG_SYNC_DIR="${DRUPAL_CONFIG_SYNC_DIR:-}"
 export DRUPAL_HASH_SALT="${DRUPAL_HASH_SALT:-}"
 
 # Drupal credentials

--- a/9/debian-10/rootfs/opt/bitnami/scripts/drupal-env.sh
+++ b/9/debian-10/rootfs/opt/bitnami/scripts/drupal-env.sh
@@ -78,6 +78,7 @@ export DRUPAL_SITE_NAME="${DRUPAL_SITE_NAME:-My blog}" # only used during the fi
 export DRUPAL_SKIP_BOOTSTRAP="${DRUPAL_SKIP_BOOTSTRAP:-}" # only used during the first initialization
 export DRUPAL_ENABLE_MODULES="${DRUPAL_ENABLE_MODULES:-}" # only used during the first initialization
 export DRUPAL_CONFIG_DIR="${DRUPAL_CONFIG_DIR:-sites/default/files/config}"
+export DRUPAL_HASH_SALT="${DRUPAL_HASH_SALT:-}"
 
 # Drupal credentials
 export DRUPAL_USERNAME="${DRUPAL_USERNAME:-user}" # only used during the first initialization

--- a/9/debian-10/rootfs/opt/bitnami/scripts/drupal-env.sh
+++ b/9/debian-10/rootfs/opt/bitnami/scripts/drupal-env.sh
@@ -77,7 +77,7 @@ export DRUPAL_PROFILE="${DRUPAL_PROFILE:-standard}" # only used during the first
 export DRUPAL_SITE_NAME="${DRUPAL_SITE_NAME:-My blog}" # only used during the first initialization
 export DRUPAL_SKIP_BOOTSTRAP="${DRUPAL_SKIP_BOOTSTRAP:-}" # only used during the first initialization
 export DRUPAL_ENABLE_MODULES="${DRUPAL_ENABLE_MODULES:-}" # only used during the first initialization
-export DRUPAL_CONFIG_DIR="${DRUPAL_CONFIG_DIR:-sites/default/files/config}"
+export DRUPAL_CONFIG_SYNC_DIR="${DRUPAL_CONFIG_SYNC_DIR:-sites/default/files/config}"
 export DRUPAL_HASH_SALT="${DRUPAL_HASH_SALT:-}"
 
 # Drupal credentials

--- a/9/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
+++ b/9/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
@@ -151,7 +151,7 @@ drupal_initialize() {
                 drupal_set_database_ssl_settings
             fi
             drupal_create_config_directory "$DRUPAL_BASE_DIR/$DRUPAL_CONFIG_SYNC_DIR"
-            drupal_conf_set "\$settings['config_sync_directory']" "$DRUPAL_CONFIG_SYNC_DIR" no
+            drupal_conf_set "\$settings['config_sync_directory']" "$DRUPAL_CONFIG_SYNC_DIR"
             drupal_set_hash_salt
             drupal_update_database
         fi

--- a/9/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
+++ b/9/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
@@ -150,8 +150,13 @@ drupal_initialize() {
             else
                 drupal_set_database_ssl_settings
             fi
+
+            # Drupal expects a directory for storing site configuration
+            # For more info see https://www.drupal.org/docs/configuration-management
             drupal_create_config_directory "$DRUPAL_BASE_DIR/$DRUPAL_CONFIG_SYNC_DIR"
             drupal_conf_set "\$settings['config_sync_directory']" "$DRUPAL_CONFIG_SYNC_DIR"
+
+            # Drupal needs a hash value to build one-time login links, cancel links, form tokens, etc.
             drupal_set_hash_salt
             drupal_update_database
         fi

--- a/9/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
+++ b/9/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
@@ -305,15 +305,11 @@ drupal_site_install() {
 #########################
 drupal_create_config_directory() {
     if [[ -z $DRUPAL_CONFIG_SYNC_DIR ]]; then
-        # In order to use Drush commands we need to have a value for
-        # config_sync_directory or it will throw an error so we add a
-        # temp value here first
-        drupal_conf_set "\$settings['config_sync_directory']" "temp" no
-        DRUPAL_CONFIG_SYNC_DIR="sites/default/files/config_$(drush eval "echo(Drupal\Component\Utility\Crypt::randomBytesBase64(55))")"
-        debug_execute mkdir "$DRUPAL_BASE_DIR/$DRUPAL_CONFIG_SYNC_DIR"
-    else
-        debug_execute mkdir "$@"
+    local config_sync_dir="${DRUPAL_CONFIG_SYNC_DIR:-}"
+    if is_empty_value "$config_sync_dir"; then
+        config_sync_dir="${DRUPAL_BASE_DIR}/sites/default/files/config_$(generate_random_string -t alphanumeric -c 16)"
     fi
+    ensure_dir_exists "$config_sync_dir"
 }
 
 

--- a/9/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
+++ b/9/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
@@ -153,8 +153,7 @@ drupal_initialize() {
 
             # Drupal expects a directory for storing site configuration
             # For more info see https://www.drupal.org/docs/configuration-management
-            drupal_create_config_directory "$DRUPAL_BASE_DIR/$DRUPAL_CONFIG_SYNC_DIR"
-            drupal_conf_set "\$settings['config_sync_directory']" "$DRUPAL_CONFIG_SYNC_DIR"
+            drupal_create_config_directory
 
             # Drupal needs a hash value to build one-time login links, cancel links, form tokens, etc.
             drupal_set_hash_salt
@@ -309,6 +308,7 @@ drupal_create_config_directory() {
         config_sync_dir="${DRUPAL_BASE_DIR}/sites/default/files/config_$(generate_random_string -t alphanumeric -c 16)"
     fi
     ensure_dir_exists "$config_sync_dir"
+    drupal_conf_set "\$settings['config_sync_directory']" "$config_sync_dir"
 }
 
 ########################

--- a/9/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
+++ b/9/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
@@ -289,6 +289,15 @@ drupal_site_install() {
     fi
 }
 
+########################
+# Drupal Create Config Directory
+# Globals:
+#   *
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
 drupal_create_config_directory() {
 	if [[ -z $DRUPAL_CONFIG_SYNC_DIR ]]; then
 		# In order to use Drush commands we need to have a value for

--- a/9/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
+++ b/9/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
@@ -151,7 +151,6 @@ drupal_initialize() {
 			drupal_create_config_directory "$DRUPAL_BASE_DIR/$DRUPAL_CONFIG_DIR"
 			drupal_conf_set "\$settings['config_sync_directory']" "$DRUPAL_CONFIG_DIR" no
 			drupal_set_hash_salt
-			cat /opt/bitnami/drupal/sites/default/settings.php
             drupal_update_database
         fi
 

--- a/9/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
+++ b/9/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
@@ -285,8 +285,18 @@ drupal_site_install() {
 }
 
 drupal_create_config_directory() {
-	debug_execute mkdir "$@"
+	if [[ -z $DRUPAL_CONFIG_SYNC_DIR ]]; then
+		# In order to use Drush commands we need to have a value for
+		# config_sync_directory or it will throw an error so we add a
+		# temp value here first
+		drupal_conf_set "\$settings['config_sync_directory']" "temp" no
+		DRUPAL_CONFIG_SYNC_DIR="sites/default/files/config_$(drush eval "echo(Drupal\Component\Utility\Crypt::randomBytesBase64(55))")"
+		debug_execute mkdir "$DRUPAL_BASE_DIR/$DRUPAL_CONFIG_SYNC_DIR"
+	else
+		debug_execute mkdir "$@"
+	fi
 }
+
 
 drupal_set_hash_salt() {
 	if [[ -z $DRUPAL_HASH_SALT ]]; then

--- a/9/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
+++ b/9/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
@@ -145,19 +145,19 @@ drupal_initialize() {
             fi
         else
             info "An already initialized Drupal database was provided, configuration will be skipped"
-			if is_empty_value "$DRUPAL_DATABASE_TLS_CA_FILE"; then
-				drupal_set_database_settings
-			else
-				drupal_set_database_ssl_settings
-			fi
-			drupal_create_config_directory "$DRUPAL_BASE_DIR/$DRUPAL_CONFIG_SYNC_DIR"
-			drupal_conf_set "\$settings['config_sync_directory']" "$DRUPAL_CONFIG_SYNC_DIR" no
-			drupal_set_hash_salt
+            if is_empty_value "$DRUPAL_DATABASE_TLS_CA_FILE"; then
+                drupal_set_database_settings
+            else
+                drupal_set_database_ssl_settings
+            fi
+            drupal_create_config_directory "$DRUPAL_BASE_DIR/$DRUPAL_CONFIG_SYNC_DIR"
+            drupal_conf_set "\$settings['config_sync_directory']" "$DRUPAL_CONFIG_SYNC_DIR" no
+            drupal_set_hash_salt
             drupal_update_database
         fi
 
-		info "Flushing Drupal cache"
-		drupal_flush_cache
+        info "Flushing Drupal cache"
+        drupal_flush_cache
 
         info "Persisting Drupal installation"
         persist_app "$app_name" "$DRUPAL_DATA_TO_PERSIST"
@@ -299,25 +299,25 @@ drupal_site_install() {
 #   None
 #########################
 drupal_create_config_directory() {
-	if [[ -z $DRUPAL_CONFIG_SYNC_DIR ]]; then
-		# In order to use Drush commands we need to have a value for
-		# config_sync_directory or it will throw an error so we add a
-		# temp value here first
-		drupal_conf_set "\$settings['config_sync_directory']" "temp" no
-		DRUPAL_CONFIG_SYNC_DIR="sites/default/files/config_$(drush eval "echo(Drupal\Component\Utility\Crypt::randomBytesBase64(55))")"
-		debug_execute mkdir "$DRUPAL_BASE_DIR/$DRUPAL_CONFIG_SYNC_DIR"
-	else
-		debug_execute mkdir "$@"
-	fi
+    if [[ -z $DRUPAL_CONFIG_SYNC_DIR ]]; then
+        # In order to use Drush commands we need to have a value for
+        # config_sync_directory or it will throw an error so we add a
+        # temp value here first
+        drupal_conf_set "\$settings['config_sync_directory']" "temp" no
+        DRUPAL_CONFIG_SYNC_DIR="sites/default/files/config_$(drush eval "echo(Drupal\Component\Utility\Crypt::randomBytesBase64(55))")"
+        debug_execute mkdir "$DRUPAL_BASE_DIR/$DRUPAL_CONFIG_SYNC_DIR"
+    else
+        debug_execute mkdir "$@"
+    fi
 }
 
 
 drupal_set_hash_salt() {
-	if [[ -z $DRUPAL_HASH_SALT ]]; then
-		drupal_conf_set "\$settings['hash_salt']" "$(drush eval "echo(Drupal\Component\Utility\Crypt::randomBytesBase64(55))")" no
-	else
-		drupal_conf_set "\$settings['hash_salt']" "$DRUPAL_HASH_SALT" no
-	fi
+    if [[ -z $DRUPAL_HASH_SALT ]]; then
+        drupal_conf_set "\$settings['hash_salt']" "$(drush eval "echo(Drupal\Component\Utility\Crypt::randomBytesBase64(55))")" no
+    else
+        drupal_conf_set "\$settings['hash_salt']" "$DRUPAL_HASH_SALT" no
+    fi
 }
 
 ########################

--- a/9/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
+++ b/9/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
@@ -147,11 +147,11 @@ drupal_initialize() {
             drupal_flush_cache
         else
             info "An already initialized Drupal database was provided, configuration will be skipped"
-			mkdir $BITNAMI_ROOT_DIR/drupal/sites/default/files/sync
-			drupal_set_database_settings
-			drupal_conf_set "\$settings['config_sync_directory']" "files/sync" yes
+			mkdir "$DRUPAL_BASE_DIR/$DRUPAL_CONFIG_DIR"
+			drupal_conf_set "\$settings['config_sync_directory']" "$DRUPAL_CONFIG_DIR" no
 			drupal_conf_set "\$settings['hash_salt']" "helloworld" yes
-			# cat /opt/bitnami/drupal/sites/default/settings.php
+			drupal_set_database_settings
+			cat /opt/bitnami/drupal/sites/default/settings.php
             drupal_update_database
         fi
 

--- a/9/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
+++ b/9/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
@@ -147,10 +147,10 @@ drupal_initialize() {
             drupal_flush_cache
         else
             info "An already initialized Drupal database was provided, configuration will be skipped"
+			drupal_set_database_settings
 			drupal_create_config_directory "$DRUPAL_BASE_DIR/$DRUPAL_CONFIG_DIR"
 			drupal_conf_set "\$settings['config_sync_directory']" "$DRUPAL_CONFIG_DIR" no
-			drupal_conf_set "\$settings['hash_salt']" "helloworld" yes
-			drupal_set_database_settings
+			drupal_set_hash_salt
 			cat /opt/bitnami/drupal/sites/default/settings.php
             drupal_update_database
         fi
@@ -287,6 +287,14 @@ drupal_site_install() {
 
 drupal_create_config_directory() {
 	debug_execute mkdir "$@"
+}
+
+drupal_set_hash_salt() {
+	if [[ -z $DRUPAL_HASH_SALT ]]; then
+		drupal_conf_set "\$settings['hash_salt']" "$(drush eval "echo(Drupal\Component\Utility\Crypt::randomBytesBase64(55))")" no
+	else
+		drupal_conf_set "\$settings['hash_salt']" "$DRUPAL_HASH_SALT" no
+	fi
 }
 
 ########################

--- a/9/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
+++ b/9/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
@@ -148,8 +148,8 @@ drupal_initialize() {
         else
             info "An already initialized Drupal database was provided, configuration will be skipped"
 			drupal_set_database_settings
-			drupal_create_config_directory "$DRUPAL_BASE_DIR/$DRUPAL_CONFIG_DIR"
-			drupal_conf_set "\$settings['config_sync_directory']" "$DRUPAL_CONFIG_DIR" no
+			drupal_create_config_directory "$DRUPAL_BASE_DIR/$DRUPAL_CONFIG_SYNC_DIR"
+			drupal_conf_set "\$settings['config_sync_directory']" "$DRUPAL_CONFIG_SYNC_DIR" no
 			drupal_set_hash_salt
             drupal_update_database
         fi

--- a/9/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
+++ b/9/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
@@ -147,6 +147,11 @@ drupal_initialize() {
             drupal_flush_cache
         else
             info "An already initialized Drupal database was provided, configuration will be skipped"
+			mkdir $BITNAMI_ROOT_DIR/drupal/sites/default/files/sync
+			drupal_set_database_settings
+			drupal_conf_set "\$settings['config_sync_directory']" "files/sync" yes
+			drupal_conf_set "\$settings['hash_salt']" "helloworld" yes
+			# cat /opt/bitnami/drupal/sites/default/settings.php
             drupal_update_database
         fi
 

--- a/9/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
+++ b/9/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
@@ -147,7 +147,11 @@ drupal_initialize() {
             drupal_flush_cache
         else
             info "An already initialized Drupal database was provided, configuration will be skipped"
-			drupal_set_database_settings
+			if is_empty_value "$DRUPAL_DATABASE_TLS_CA_FILE"; then
+				drupal_set_database_settings
+			else
+				drupal_set_database_ssl_settings
+			fi
 			drupal_create_config_directory "$DRUPAL_BASE_DIR/$DRUPAL_CONFIG_SYNC_DIR"
 			drupal_conf_set "\$settings['config_sync_directory']" "$DRUPAL_CONFIG_SYNC_DIR" no
 			drupal_set_hash_salt

--- a/9/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
+++ b/9/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
@@ -442,6 +442,22 @@ drupal_set_database_ssl_settings() {
 EOF
 }
 
+drupal_set_database_settings() {
+    cat >>"$DRUPAL_CONF_FILE" <<EOF
+\$databases['default']['default'] = array ( // Database block with SSL support
+  'database' => '${DRUPAL_DATABASE_NAME}',
+  'username' => '${DRUPAL_DATABASE_USER}',
+  'password' => '${DRUPAL_DATABASE_PASSWORD}',
+  'prefix' => '',
+  'host' => '${DRUPAL_DATABASE_HOST}',
+  'port' => '${DRUPAL_DATABASE_PORT_NUMBER}',
+  'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
+  'driver' => 'mysql',
+);
+EOF
+}
+
+
 ########################
 # Drupal remove duplicated database block from settings file
 # Globals:

--- a/9/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
+++ b/9/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
@@ -143,8 +143,6 @@ drupal_initialize() {
                 info "Configuring SMTP"
                 drupal_configure_smtp
             fi
-            info "Flushing Drupal cache"
-            drupal_flush_cache
         else
             info "An already initialized Drupal database was provided, configuration will be skipped"
 			if is_empty_value "$DRUPAL_DATABASE_TLS_CA_FILE"; then
@@ -157,6 +155,9 @@ drupal_initialize() {
 			drupal_set_hash_salt
             drupal_update_database
         fi
+
+		info "Flushing Drupal cache"
+		drupal_flush_cache
 
         info "Persisting Drupal installation"
         persist_app "$app_name" "$DRUPAL_DATA_TO_PERSIST"

--- a/9/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
+++ b/9/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
@@ -304,7 +304,6 @@ drupal_site_install() {
 #   None
 #########################
 drupal_create_config_directory() {
-    if [[ -z $DRUPAL_CONFIG_SYNC_DIR ]]; then
     local config_sync_dir="${DRUPAL_CONFIG_SYNC_DIR:-}"
     if is_empty_value "$config_sync_dir"; then
         config_sync_dir="${DRUPAL_BASE_DIR}/sites/default/files/config_$(generate_random_string -t alphanumeric -c 16)"

--- a/9/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
+++ b/9/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
@@ -147,7 +147,7 @@ drupal_initialize() {
             drupal_flush_cache
         else
             info "An already initialized Drupal database was provided, configuration will be skipped"
-			mkdir "$DRUPAL_BASE_DIR/$DRUPAL_CONFIG_DIR"
+			drupal_create_config_directory "$DRUPAL_BASE_DIR/$DRUPAL_CONFIG_DIR"
 			drupal_conf_set "\$settings['config_sync_directory']" "$DRUPAL_CONFIG_DIR" no
 			drupal_conf_set "\$settings['hash_salt']" "helloworld" yes
 			drupal_set_database_settings
@@ -283,6 +283,10 @@ drupal_site_install() {
     if am_i_root; then
         configure_permissions_ownership "$DRUPAL_CONF_FILE" -u "root" -g "$WEB_SERVER_DAEMON_USER" -f "644"
     fi
+}
+
+drupal_create_config_directory() {
+	debug_execute mkdir "$@"
 }
 
 ########################

--- a/9/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
+++ b/9/debian-10/rootfs/opt/bitnami/scripts/libdrupal.sh
@@ -312,13 +312,21 @@ drupal_create_config_directory() {
     ensure_dir_exists "$config_sync_dir"
 }
 
-
+########################
+# Drupal Create Hash Salt
+# Globals:
+#   *
+# Arguments:
+#   None
+# Returns:
+#   None
+#########################
 drupal_set_hash_salt() {
-    if [[ -z $DRUPAL_HASH_SALT ]]; then
-        drupal_conf_set "\$settings['hash_salt']" "$(drush eval "echo(Drupal\Component\Utility\Crypt::randomBytesBase64(55))")" no
-    else
-        drupal_conf_set "\$settings['hash_salt']" "$DRUPAL_HASH_SALT" no
+    local hash_salt="${DRUPAL_HASH_SALT:-}"
+    if is_empty_value "$hash_salt"; then
+        hash_salt="$(generate_random_string -t alphanumeric -c 32)"
     fi
+    drupal_conf_set "\$settings['hash_salt']" "$hash_salt"
 }
 
 ########################

--- a/README.md
+++ b/README.md
@@ -230,6 +230,8 @@ Available environment variables:
  - `DRUPAL_USERNAME`: Drupal application username. Default: **user**
  - `DRUPAL_PASSWORD`: Drupal application password. Default: **bitnami**
  - `DRUPAL_EMAIL`: Drupal application email. Default: **user@example.com**
+ - `DRUPAL_CONFIG_SYNC_DIR`: Drupal configuration file directory. Default: **sites/default/files/config_${RANDOM_STRING}**
+ - `DRUPAL_HASH_SALT`: Salt used for hardening against SQL injection. Default: **A random string**
 
 ##### Use an existing database
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This PR is meant to fix the bug described in this [ticket](https://github.com/bitnami/charts/issues/5434) within the bitnami/charts repository.

Currently this PR is pretty rough/hacky, but I'm creating it now so I can start a discussion with the Bitnami team about the best way to fix this bug.  The original issue (linked above) is that when skipping the drupal bootstrap step the generated settings file doesn't have any of the information it needs to connect to the existing database and is missing some other important config information.  

**Current Approach**
As I worked on this I realized there were three items missing from the settings.php file when skipping the bootstrap step:
1. DB Connection Info (the $databases array)
2. The config sync directory (the $settings['config_sync_directory'] value)
3. The hash salt (the $settings['hash_salt'] value)

To add the DB connection info I just copied the drupal_set_database_ssl_settings (in libdrupal.sh) functions into a new function called drupal_set_database_settings and removed the SSL info for the pdo connection.  For the config_sync directory I just used the drupal_conf_set function to add the correct setting and I also had to create that directory ahead of time.  Right now its hardcoded, but it should be controllable by the user.  Finally, I used the drupal_conf_set function to create the hash salt, and again for now its hardcoded but it can be changed to something user controlled.  I'll keep working on this, but I'd like to hear if the Bitnami team thinks this is the proper direction to fix the bug.

**Applicable issues**

https://github.com/bitnami/charts/issues/5434

Thank you